### PR TITLE
Add Markdown merge utility and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # md_files_merge
+
+Command line tool and Python utility for merging Markdown files from a
+directory tree into a single document. The merger walks the target directory in
+alphabetical order and prepends the contents of each Markdown file with a
+synthetic heading that contains the file's relative path wrapped by a unique
+delimiter (default: `<<<>>>`).
+
+## Command line usage
+
+Run the tool by executing the module directly:
+
+```bash
+python -m md_files_merge <root_directory> <output_file> [--heading-level N] [--delimiter TEXT]
+```
+
+**Arguments**
+
+- `root_directory`: Directory to search recursively for `.md` files.
+- `output_file`: Path to the Markdown file that will contain the merged
+  contents.
+- `--heading-level`: Optional heading level (1–6) for the synthetic headings.
+- `--delimiter`: Optional delimiter to wrap the heading content and keep it
+  unique from the original file contents.
+
+## Programmatic usage
+
+The merger can be imported and used from another Python module:
+
+```python
+from md_files_merge import merge_markdown_files
+
+merge_markdown_files(
+    "docs",
+    "merged.md",
+    heading_level=2,
+    delimiter="<<<>>>",
+)
+```
+
+The function returns the path to the generated Markdown file.

--- a/md_files_merge/__init__.py
+++ b/md_files_merge/__init__.py
@@ -1,0 +1,13 @@
+"""Markdown merging utilities."""
+
+from .merger import (
+    DEFAULT_DELIMITER,
+    DEFAULT_HEADING_LEVEL,
+    merge_markdown_files,
+)
+
+__all__ = [
+    "merge_markdown_files",
+    "DEFAULT_DELIMITER",
+    "DEFAULT_HEADING_LEVEL",
+]

--- a/md_files_merge/__main__.py
+++ b/md_files_merge/__main__.py
@@ -1,0 +1,62 @@
+"""Command line interface for the Markdown merger."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+from .merger import DEFAULT_DELIMITER, DEFAULT_HEADING_LEVEL, merge_markdown_files
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Merge Markdown files from a directory tree into a single Markdown "
+            "document."
+        )
+    )
+    parser.add_argument(
+        "root",
+        type=Path,
+        help="Directory to search recursively for Markdown files.",
+    )
+    parser.add_argument(
+        "output",
+        type=Path,
+        help="File path where the merged Markdown document will be written.",
+    )
+    parser.add_argument(
+        "--heading-level",
+        type=int,
+        default=DEFAULT_HEADING_LEVEL,
+        help=(
+            "Heading level (1-6) used to separate individual Markdown files in "
+            "the merged output."
+        ),
+    )
+    parser.add_argument(
+        "--delimiter",
+        default=DEFAULT_DELIMITER,
+        help=(
+            "Delimiter that wraps each heading to keep it distinct from "
+            "existing content."
+        ),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> Path:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    output_path = merge_markdown_files(
+        args.root,
+        args.output,
+        heading_level=args.heading_level,
+        delimiter=args.delimiter,
+    )
+    print(f"Merged Markdown written to {output_path}")
+    return output_path
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/md_files_merge/merger.py
+++ b/md_files_merge/merger.py
@@ -1,0 +1,119 @@
+"""Utilities for merging Markdown files into a single document."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, Tuple
+
+DEFAULT_HEADING_LEVEL = 1
+DEFAULT_DELIMITER = "<<<>>>"
+
+MarkdownPathPair = Tuple[Path, Path]
+
+
+def _validate_heading_level(level: int) -> int:
+    if not 1 <= level <= 6:
+        raise ValueError("heading_level must be between 1 and 6")
+    return level
+
+
+def _collect_markdown_files(root: Path, output: Path | None = None) -> List[MarkdownPathPair]:
+    """Collect Markdown files under ``root``.
+
+    Parameters
+    ----------
+    root:
+        The directory whose Markdown files should be discovered.
+    output:
+        Optional path to the output file. If provided and the path is within
+        ``root`` it will be skipped during collection to avoid self-inclusion.
+
+    Returns
+    -------
+    list[tuple[pathlib.Path, pathlib.Path]]
+        A list of tuples containing the absolute path to the Markdown file and
+        its path relative to ``root``.
+    """
+
+    markdown_files: List[MarkdownPathPair] = []
+    resolved_output = output.resolve() if output is not None else None
+
+    for directory, dirnames, filenames in os.walk(root):
+        dirnames.sort()
+        markdown_names = sorted(
+            name for name in filenames if name.lower().endswith(".md")
+        )
+        for name in markdown_names:
+            file_path = Path(directory) / name
+            if resolved_output is not None and file_path.resolve() == resolved_output:
+                continue
+            markdown_files.append((file_path, file_path.relative_to(root)))
+
+    return markdown_files
+
+
+def merge_markdown_files(
+    root: str | Path,
+    output: str | Path,
+    *,
+    heading_level: int = DEFAULT_HEADING_LEVEL,
+    delimiter: str = DEFAULT_DELIMITER,
+) -> Path:
+    """Merge Markdown files under ``root`` into a single document.
+
+    The Markdown files are discovered recursively in alphabetical order and the
+    content of each file is separated in the output by a heading that includes
+    the relative path of the original file. This function can be imported and
+    used programmatically as part of larger workflows or invoked through the
+    accompanying command line interface.
+
+    Parameters
+    ----------
+    root:
+        Directory to search for Markdown files.
+    output:
+        File path where the merged Markdown document will be written.
+    heading_level:
+        Heading level to use for separating individual file contents.
+    delimiter:
+        Unique delimiter used around each heading's path to avoid collisions
+        with existing headings in the source files.
+
+    Returns
+    -------
+    pathlib.Path
+        The path to the written Markdown file.
+    """
+
+    root_path = Path(root).expanduser().resolve()
+    if not root_path.is_dir():
+        raise ValueError(f"root path '{root}' does not exist or is not a directory")
+
+    output_path = Path(output).expanduser().resolve()
+
+    _validate_heading_level(heading_level)
+    if not delimiter:
+        raise ValueError("delimiter must be a non-empty string")
+
+    markdown_files = _collect_markdown_files(root_path, output_path)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    heading_prefix = "#" * heading_level
+
+    with output_path.open("w", encoding="utf-8") as merged_file:
+        for index, (file_path, relative_path) in enumerate(markdown_files):
+            if index:
+                merged_file.write("\n\n")
+
+            heading = f"{heading_prefix} {delimiter} {relative_path.as_posix()} {delimiter}"
+            merged_file.write(heading + "\n\n")
+
+            content = file_path.read_text(encoding="utf-8")
+            merged_file.write(content.rstrip("\n"))
+            merged_file.write("\n")
+
+    return output_path
+
+
+__all__ = ["merge_markdown_files", "DEFAULT_DELIMITER", "DEFAULT_HEADING_LEVEL"]


### PR DESCRIPTION
## Summary
- add a reusable `merge_markdown_files` helper that merges Markdown files recursively with configurable headings and delimiters
- expose a command line entry point via `python -m md_files_merge`
- document usage and ignore Python bytecode caches

## Testing
- python -m md_files_merge --help

------
https://chatgpt.com/codex/tasks/task_e_68d1a532b9388330858ed02e38e08515