### PR TITLE
Remove headings from merged output and prioritize README

### DIFF
--- a/md_files_merge/__main__.py
+++ b/md_files_merge/__main__.py
@@ -30,16 +30,16 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=DEFAULT_HEADING_LEVEL,
         help=(
-            "Heading level (1-6) used to separate individual Markdown files in "
-            "the merged output."
+            "Deprecated. Retained for backwards compatibility and has no "
+            "effect on the output."
         ),
     )
     parser.add_argument(
         "--delimiter",
         default=DEFAULT_DELIMITER,
         help=(
-            "Delimiter that wraps each heading to keep it distinct from "
-            "existing content."
+            "Deprecated. Retained for backwards compatibility and has no "
+            "effect on the output."
         ),
     )
     return parser


### PR DESCRIPTION
## Summary
- stop emitting path headings and delimiter markers so the merged document only contains the original Markdown content
- ensure README.md files (matched case-insensitively) are merged before other Markdown files within the same directory
- clarify in the CLI help that heading and delimiter options are deprecated compatibility shims

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d1ba6b20c48330942dcfc3854d79c9